### PR TITLE
feat/be: 북마크 순으로 책 목록 조회 기능 구현

### DIFF
--- a/ingq/app/macmorning.py
+++ b/ingq/app/macmorning.py
@@ -37,6 +37,7 @@ def create_app() -> FastAPI:
         "/v1/login",
         "/v1/signup",
         "/v1/books",
+        "/v1/books/best",
         "/docs",
         "/openapi.json",
         "/redoc",

--- a/ingq/book/application/book_service.py
+++ b/ingq/book/application/book_service.py
@@ -66,6 +66,18 @@ class BookService:
             cursor=cursor,
         )
 
+    def get_best_books(
+        self,
+        user_id: Optional[str],
+        limit: int,
+        cursor: Optional[str] = None,
+    ) -> PaginatedBookItem:
+        return self.book_repository.get_best_books(
+            user_id,
+            limit=limit,
+            cursor=cursor,
+        )
+
     def get_book_by_id_or_throw(self, book_id: int) -> Book:
         book = self.book_repository.find_by_id(book_id)
         if not book:

--- a/ingq/book/domain/repository/book_repository.py
+++ b/ingq/book/domain/repository/book_repository.py
@@ -43,5 +43,14 @@ class BookRepository(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
+    def get_best_books(
+        self,
+        user_id: Optional[str],
+        limit: int,
+        cursor: Optional[str],
+    ) -> PaginatedBookItem:
+        raise NotImplementedError
+
+    @abstractmethod
     def find_by_id(self, book_id: int) -> Optional[Book]:
         raise NotImplementedError

--- a/ingq/book/dto/schemas.py
+++ b/ingq/book/dto/schemas.py
@@ -94,6 +94,7 @@ class BookItem(BaseModel):
         default=None,
         description="로그인 완료된 사용자에게만 제공, 비로그인 시 미포함 필드",
     )
+    bookmark_count: Optional[int] = None
 
 
 # ============================================================================

--- a/ingq/book/infra/pagination/cursor.py
+++ b/ingq/book/infra/pagination/cursor.py
@@ -117,11 +117,6 @@ def validate_and_get_cursor(
         or order_strategy == OrderStrategy.UPDATED_AT_ASC
     ):
         return UpdatedAtCursor.decode(cursor)
-    elif (
-        order_strategy == OrderStrategy.BOOKMARK_COUNT_DESC
-        or order_strategy == OrderStrategy.BOOKMARK_COUNT_ASC
-    ):
-        return BookmarkCountCursor.decode(cursor)
     else:
         raise UnsupportedStrategyException(
             f"{order_strategy}는 지원하지 않는 order_strategy입니다."
@@ -143,8 +138,6 @@ def create_next_cursor(
         OrderStrategy.CREATED_AT_DESC: (CreatedAtCursor, "created_at"),
         OrderStrategy.UPDATED_AT_ASC: (UpdatedAtCursor, "updated_at"),
         OrderStrategy.UPDATED_AT_DESC: (UpdatedAtCursor, "updated_at"),
-        OrderStrategy.BOOKMARK_COUNT_ASC: (BookmarkCountCursor, "bookmark_count"),
-        OrderStrategy.BOOKMARK_COUNT_DESC: (BookmarkCountCursor, "bookmark_count"),
     }
 
     cursor_class, field_name = cursor_config[order_strategy]

--- a/ingq/book/infra/pagination/cursor.py
+++ b/ingq/book/infra/pagination/cursor.py
@@ -100,7 +100,7 @@ class BookmarkCountCursor(Cursor):
 
 def validate_and_get_cursor(
     cursor: str, order_strategy: OrderStrategy
-) -> Optional[Union[CreatedAtCursor, UpdatedAtCursor, BookmarkCountCursor]]:
+) -> Optional[Union[CreatedAtCursor, UpdatedAtCursor]]:
     """
     커서 형식 및 타입 검증 후 Cursor 객체 반환
     """
@@ -121,6 +121,13 @@ def validate_and_get_cursor(
         raise UnsupportedStrategyException(
             f"{order_strategy}는 지원하지 않는 order_strategy입니다."
         )
+
+
+def get_bookmark_cursor(cursor: str) -> Optional[BookmarkCountCursor]:
+    if not cursor:
+        return None
+
+    return BookmarkCountCursor.decode(cursor)
 
 
 def create_next_cursor(
@@ -144,5 +151,20 @@ def create_next_cursor(
     field_value = getattr(last_book, field_name)
     cursor_params = {field_name: field_value, "book_id": last_book.id}
     cursor_instance = cursor_class(**cursor_params)
+
+    return Cursor.encode(cursor_instance)
+
+
+def create_next_bookmark_cursor(
+    books_with_bookmark_count: list[tuple[Book, int]], has_next: bool
+) -> Optional[str]:
+    if not has_next or not books_with_bookmark_count:
+        return None
+
+    last_book = books_with_bookmark_count[-1][0]
+    last_bookmark_count = books_with_bookmark_count[-1][1]
+    print("l\n\n\n:", last_book, last_bookmark_count)
+    cursor_params = {"bookmark_count": last_bookmark_count, "book_id": last_book.id}
+    cursor_instance = BookmarkCountCursor(**cursor_params)
 
     return Cursor.encode(cursor_instance)

--- a/ingq/book/infra/pagination/cursor.py
+++ b/ingq/book/infra/pagination/cursor.py
@@ -163,7 +163,6 @@ def create_next_bookmark_cursor(
 
     last_book = books_with_bookmark_count[-1][0]
     last_bookmark_count = books_with_bookmark_count[-1][1]
-    print("l\n\n\n:", last_book, last_bookmark_count)
     cursor_params = {"bookmark_count": last_bookmark_count, "book_id": last_book.id}
     cursor_instance = BookmarkCountCursor(**cursor_params)
 

--- a/ingq/book/infra/pagination/order_strategy.py
+++ b/ingq/book/infra/pagination/order_strategy.py
@@ -6,5 +6,3 @@ class OrderStrategy(StrEnum):
     CREATED_AT_ASC = "created_at_asc"
     UPDATED_AT_DESC = "updated_at_desc"
     UPDATED_AT_ASC = "updated_at_asc"
-    BOOKMARK_COUNT_DESC = "bookmark_count_desc"
-    BOOKMARK_COUNT_ASC = "bookmark_count_asc"

--- a/ingq/book/infra/repository/book_query_builder.py
+++ b/ingq/book/infra/repository/book_query_builder.py
@@ -150,7 +150,6 @@ class BookQueryBuilder:
         query: Query, cursor: Optional[Cursor]
     ) -> Query:
         query = query.order_by(desc(literal_column("bookmark_count")), desc(Book.id))
-        print("book-query-builder-ordering:", query)
         if cursor:
             query = query.filter(
                 (

--- a/ingq/book/infra/repository/book_query_builder.py
+++ b/ingq/book/infra/repository/book_query_builder.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from sqlalchemy import asc, desc
+from sqlalchemy import asc, desc, func, literal_column
 from sqlalchemy.orm import Query, Session
 
 from book.infra.db_models.book import Book
@@ -59,6 +59,46 @@ class BookQueryBuilder:
         )
 
     @staticmethod
+    def build_books_by_bookmark_count_query(
+        db: Session, user_id: Optional[str] = None
+    ) -> Query:
+        bookmark_count = (
+            db.query(Bookmark.book_id, func.count(Bookmark.id).label("bookmark_count"))
+            .group_by(Bookmark.book_id)
+            .subquery()
+        )
+
+        if user_id:
+            return (
+                db.query(
+                    Book,
+                    User.username,
+                    Bookmark.id.isnot(None).label("is_bookmarked"),
+                    func.coalesce(bookmark_count.c.bookmark_count, 0).label(
+                        "bookmark_count"
+                    ),
+                )
+                .join(User, Book.user_id == User.id)
+                .outerjoin(
+                    Bookmark,
+                    (Bookmark.book_id == Book.id) & (Bookmark.user_id == user_id),
+                )
+                .outerjoin(bookmark_count, Book.id == bookmark_count.c.book_id)
+            )
+        else:
+            return (
+                db.query(
+                    Book,
+                    User.username,
+                    func.coalesce(bookmark_count.c.bookmark_count, 0).label(
+                        "bookmark_count"
+                    ),
+                )
+                .join(User, Book.user_id == User.id)
+                .outerjoin(bookmark_count, Book.id == bookmark_count.c.book_id)
+            )
+
+    @staticmethod
     def apply_ordering_and_filtering(
         query: Query, order_strategy: OrderStrategy, cursor: Optional[Cursor]
     ) -> Query:
@@ -103,4 +143,26 @@ class BookQueryBuilder:
                     )
                 )
 
+        return query
+
+    @staticmethod
+    def apply_ordering_and_filtering_with_bookmark_count(
+        query: Query, cursor: Optional[Cursor]
+    ) -> Query:
+        query = query.order_by(desc(literal_column("bookmark_count")), desc(Book.id))
+        print("book-query-builder-ordering:", query)
+        if cursor:
+            query = query.filter(
+                (
+                    func.coalesce(literal_column("bookmark_count"), 0)
+                    < cursor.bookmark_count
+                )
+                | (
+                    (
+                        func.coalesce(literal_column("bookmark_count"), 0)
+                        == cursor.bookmark_count
+                    )
+                    & (Book.id < cursor.book_id)
+                )
+            )
         return query

--- a/ingq/book/infra/repository/book_query_builder.py
+++ b/ingq/book/infra/repository/book_query_builder.py
@@ -102,9 +102,5 @@ class BookQueryBuilder:
                         & (Book.id > cursor.book_id)
                     )
                 )
-        elif order_strategy == OrderStrategy.BOOKMARK_COUNT_DESC:
-            raise NotImplementedError("bookmark_count_desc는 구현중입니다.")
-        elif order_strategy == OrderStrategy.BOOKMARK_COUNT_ASC:
-            raise NotImplementedError("bookmark_count_asc는 구현중입니다.")
 
         return query

--- a/ingq/book/interface/controller/book_controller.py
+++ b/ingq/book/interface/controller/book_controller.py
@@ -57,7 +57,7 @@ def get_all_books(
     )
 
 
-@router.get("/books/mybooks")
+@router.get("/books/mybooks", status_code=200)
 @inject
 def get_mybooks(
     request: Request,
@@ -91,7 +91,7 @@ def get_mybooks(
     )
 
 
-@router.get("/books/bookmarks")
+@router.get("/books/bookmarks", status_code=200)
 @inject
 def get_bookmarked_books(
     request: Request,
@@ -101,7 +101,7 @@ def get_bookmarked_books(
     ),
     cursor: Optional[str] = Query(None, description="커서 값"),
     book_service: BookService = Depends(Provide[Container.book_service]),
-):
+) -> PaginatedBookItem:
     """
     Cursor 기반 페이지네이션을 적용해 내가 북마크한 책 목록 조회
 
@@ -121,7 +121,7 @@ def get_bookmarked_books(
     )
 
 
-@router.get("/books/best")
+@router.get("/books/best", status_code=200)
 @inject
 def get_best_books(
     request: Request,
@@ -131,7 +131,7 @@ def get_best_books(
     jwt_token_provider: JwtTokenProvider = Depends(
         Provide[Container.jwt_token_provider]
     ),
-):
+) -> PaginatedBookItem:
     """
     Cursor 기반 페이지네이션을 적용해 북마크순 책 목록 조회
 

--- a/ingq/book/interface/controller/book_controller.py
+++ b/ingq/book/interface/controller/book_controller.py
@@ -119,3 +119,26 @@ def get_bookmarked_books(
         order_strategy=order_strategy,
         cursor=cursor,
     )
+
+
+@router.get("/books/best")
+@inject
+def get_best_books(
+    request: Request,
+    limit: int = Query(4, ge=1, description="페이지당 항목 수"),
+    cursor: Optional[str] = Query(None, description="커서 값"),
+    book_service: BookService = Depends(Provide[Container.book_service]),
+    jwt_token_provider: JwtTokenProvider = Depends(
+        Provide[Container.jwt_token_provider]
+    ),
+):
+    """
+    Cursor 기반 페이지네이션을 적용해 북마크순 책 목록 조회
+
+    - limit: 페이지당 항목 수(default = 4)
+    - cursor: 이전 페이지의 마지막 항목에 대한 커서(null 가능)
+        - base64로 인코딩된 값
+    """
+    current_user = get_optional_current_user(request, jwt_token_provider)
+    user_id = current_user.id if current_user else None
+    return book_service.get_best_books(user_id, limit=limit, cursor=cursor)

--- a/ingq/book/interface/controller/book_controller.py
+++ b/ingq/book/interface/controller/book_controller.py
@@ -44,9 +44,9 @@ def get_all_books(
     Cursor 기반 페이지네이션을 적용해 전체 책 목록 조회
 
     - limit: 페이지당 항목 수(default = 4)
-    - order_strategy: 정렬 전략(생성일자, 업데이트일자, 북마크 기준 오름,내림 차순 제공)
-        - created_at_desc, updated_at_desc, bookmark_count_desc
-        - created_at_asc, updated_at_asc, bookmark_count_asc
+    - order_strategy: 정렬 전략(생성일자, 업데이트일자 기준 오름,내림 차순 제공)
+        - created_at_desc, updated_at_desc
+        - created_at_asc, updated_at_asc
     - cursor: 이전 페이지의 마지막 항목에 대한 커서(null 가능)
         - base64로 인코딩된 값
     """
@@ -73,9 +73,9 @@ def get_mybooks(
     Cursor 기반 페이지네이션을 적용해 내가 쓴 책 목록 조회
 
     - limit: 페이지당 항목 수(default = 4)
-    - order_strategy: 정렬 전략(생성일자, 업데이트일자, 북마크 기준 오름,내림 차순 제공)
-        - created_at_desc, updated_at_desc, bookmark_count_desc
-        - created_at_asc, updated_at_asc, bookmark_count_asc
+    - order_strategy: 정렬 전략(생성일자, 업데이트일자 기준 오름,내림 차순 제공)
+        - created_at_desc, updated_at_desc
+        - created_at_asc, updated_at_asc
     - cursor: 이전 페이지의 마지막 항목에 대한 커서(null 가능)
         - base64로 인코딩된 값
     - progress: 이야기 진행 여부
@@ -106,9 +106,9 @@ def get_bookmarked_books(
     Cursor 기반 페이지네이션을 적용해 내가 북마크한 책 목록 조회
 
     - limit: 페이지당 항목 수(default = 4)
-    - order_strategy: 정렬 전략(생성일자, 업데이트일자, 북마크 기준 오름,내림 차순 제공)
-        - created_at_desc, updated_at_desc, bookmark_count_desc
-        - created_at_asc, updated_at_asc, bookmark_count_asc
+    - order_strategy: 정렬 전략(생성일자, 업데이트일자 기준 오름,내림 차순 제공)
+        - created_at_desc, updated_at_desc
+        - created_at_asc, updated_at_asc
     - cursor: 이전 페이지의 마지막 항목에 대한 커서(null 가능)
         - base64로 인코딩된 값
     """

--- a/ingq/book/utils/mapper.py
+++ b/ingq/book/utils/mapper.py
@@ -93,3 +93,40 @@ class BookMapper:
                 )
             )
         return result
+
+    @staticmethod
+    def to_book_items_with_info_and_bookmark_count(
+        books_with_info_and_count: list[tuple[Book, str, bool, int]],
+    ) -> list[BookItem]:
+        result = []
+        for book, username, is_bookmarked, bookmark_count in books_with_info_and_count:
+            result.append(
+                BookItem(
+                    book_id=book.id,
+                    title_img_url="https://placehold.co/400",
+                    title=book.title,
+                    author=username,
+                    background=book.background,
+                    is_bookmarked=is_bookmarked,
+                    bookmark_count=bookmark_count,
+                )
+            )
+        return result
+
+    @staticmethod
+    def to_book_items_with_username_and_bookmark_count(
+        books_with_username_and_count: list[tuple[Book, str, int]],
+    ) -> list[BookItem]:
+        result = []
+        for book, username, bookmark_count in books_with_username_and_count:
+            result.append(
+                BookItem(
+                    book_id=book.id,
+                    title_img_url="https://placehold.co/400",
+                    title=book.title,
+                    author=username,
+                    background=book.background,
+                    bookmark_count=bookmark_count,
+                )
+            )
+        return result


### PR DESCRIPTION
## 주의
- [X] 브랜치 방향 확인하셨나요? :)

## 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->
- close #32 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

- 북마크순으로 목록을 조회하는 `/v1/books/best` 엔드포인트 추가
  - 목록 조회 시 반환 값으로 `bookmark_count`추가

- OrderStrategy에서 Bookmark Count 전략 제거
  - book_query_builder.py, cursor.py Bookmark Count와 관련된 로직 분리



## 리뷰 요청 사항
<!-- 팀원들이 주의 깊게 살펴봐야하는 부분 및 리뷰가 필요한 곳에 대해 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 북마크 수 기준으로 책 목록을 조회할 수 있는 새로운 엔드포인트(`/books/best`)가 추가되었습니다.
- **개선 사항**
    - 책 아이템에 북마크 수 정보가 표시됩니다.
- **문서**
    - 기존 책 목록 관련 엔드포인트의 정렬 옵션에서 북마크 수 정렬 관련 설명이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->