### PR TITLE
fix/be: created_at/updated_at 기준 정렬 시 동일 시간에는 book id를 desc로 정렬

### DIFF
--- a/ingq/book/infra/repository/book_query_builder.py
+++ b/ingq/book/infra/repository/book_query_builder.py
@@ -113,13 +113,13 @@ class BookQueryBuilder:
                     )
                 )
         elif order_strategy == OrderStrategy.CREATED_AT_ASC:
-            query = query.order_by(asc(Book.created_at), asc(Book.id))
+            query = query.order_by(asc(Book.created_at), desc(Book.id))
             if cursor:
                 query = query.filter(
                     (Book.created_at > cursor.created_at)
                     | (
                         (Book.created_at == cursor.created_at)
-                        & (Book.id > cursor.book_id)
+                        & (Book.id < cursor.book_id)
                     )
                 )
         elif order_strategy == OrderStrategy.UPDATED_AT_DESC:
@@ -133,13 +133,13 @@ class BookQueryBuilder:
                     )
                 )
         elif order_strategy == OrderStrategy.UPDATED_AT_ASC:
-            query = query.order_by(asc(Book.updated_at), asc(Book.id))
+            query = query.order_by(asc(Book.updated_at), desc(Book.id))
             if cursor:
                 query = query.filter(
                     (Book.updated_at > cursor.updated_at)
                     | (
                         (Book.updated_at == cursor.updated_at)
-                        & (Book.id > cursor.book_id)
+                        & (Book.id < cursor.book_id)
                     )
                 )
 


### PR DESCRIPTION
## 주의
- [X] 브랜치 방향 확인하셨나요? :)

## 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->
- close #37 

## PR 유형

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

- 기존: createdAt, updatedAt을 기준으로 ASC 정렬을 수행한 경우 `book_id`도 ASC 정렬을 진행
- 변경: 모든 정렬에 대해 `book_id`는 DESC 정렬 진행

## 리뷰 요청 사항
<!-- 팀원들이 주의 깊게 살펴봐야하는 부분 및 리뷰가 필요한 곳에 대해 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - `created_at` 및 `updated_at` 기준 오름차순 정렬 시, 보조 정렬 키인 `Book.id`가 내림차순으로 정렬되도록 변경되었습니다. 이에 따라 커서 필터 조건도 정렬 방식에 맞게 수정되었습니다.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->