### PR TITLE
refactor/be: Character의 age 및 characteristic 필드 타입 변경

### DIFF
--- a/ingq/book/domain/character.py
+++ b/ingq/book/domain/character.py
@@ -6,6 +6,6 @@ class Character:
     grammatical_person: str
     historical_background: str
     name: str
-    age: int
+    age: str
     gender: str
-    characteristic: list[str]
+    characteristic: str

--- a/ingq/book/dto/schemas.py
+++ b/ingq/book/dto/schemas.py
@@ -19,14 +19,16 @@ class Character(BaseModel):
         default=None, max_length=10, description="주인공 이름 (최대 10자)"
     )
 
-    age: Optional[int] = Field(default=None, ge=0, description="주인공 나이 (0 이상)")
+    age: Optional[Literal["어린이", "청소년", "청년", "노인"]] = Field(
+        default=None, description="주인공 연령층 ('어린이', '청소년', '청년', '노인')"
+    )
 
     gender: Optional[Literal["남성", "여성"]] = Field(
         default=None, description="주인공 성별 ('남성' 또는 '여성')"
     )
 
-    characteristic: Optional[list[str]] = Field(
-        default_factory=list, description="주인공 특징"
+    characteristic: Optional[str] = Field(
+        default=None, max_length=100, description="주인공 특징 (최대 100자)"
     )
 
 


### PR DESCRIPTION
## 주의
- [X] 브랜치 방향 확인하셨나요? :)

## 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->
- close #54 

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

Character의 age, character 필드 타입 변경
- age: Integer -> str ('어린이','청소년','청년','노인')
- characteristic: list[str] -> str



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 등장인물 정보에서 나이 입력 방식이 숫자에서 "어린이", "청소년", "청년", "노인" 중 하나를 선택하는 형태로 변경되었습니다.
  - 등장인물의 특성 입력이 여러 개의 항목에서 하나의 최대 100자 이내 텍스트로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->