### PR TITLE
feat/be: test login 엔드포인트 추가

### DIFF
--- a/ingq/app/macmorning.py
+++ b/ingq/app/macmorning.py
@@ -37,6 +37,7 @@ def create_app() -> FastAPI:
     app = FastAPI(lifespan=lifespan, default_response_class=ApiResponseWrapper)
 
     exempt_paths = [
+        "/v1/test-login",
         "/v1/token/reissue",
         "/v1/login",
         "/v1/signup",

--- a/ingq/auth/application/auth_service.py
+++ b/ingq/auth/application/auth_service.py
@@ -14,3 +14,6 @@ class AuthService:
     async def login(self, email: str, password: str) -> AuthToken:
         user = self.user_service.find_user_by_email_and_password(email, password)
         return await self.auth_token_service.generate_auth_token(user.id)
+
+    async def test_login(self, user_id: str) -> AuthToken:
+        return await self.auth_token_service.generate_auth_token(user_id)

--- a/ingq/auth/interface/controller/auth_controller.py
+++ b/ingq/auth/interface/controller/auth_controller.py
@@ -60,3 +60,30 @@ def sign_up(
 ) -> SignUpResponse:
     _user = user_service.register_user(user)
     return _user
+
+
+@router.post("/test-login")
+@inject
+async def test_login(
+    user_id: str,
+    auth_service: AuthService = Depends(Provide[Container.auth_service]),
+):
+    auth_token = await auth_service.test_login(user_id)
+
+    response_body = {"token_expires_in": f"{auth_token.token_expires_in}s"}
+
+    response = ApiResponseWrapper(content=success_response(response_body))
+
+    response.headers["Authorization"] = f"Bearer {auth_token.access_token}"
+
+    response.set_cookie(
+        key="refresh_token",
+        value=auth_token.refresh_token,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=REFRESH_TOKEN_EXPIRE_SECONDS,
+        path="/",
+    )
+
+    return response


### PR DESCRIPTION
## 주의
- [X] 브랜치 방향 확인하셨나요? :)

## 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->
- close #63 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

- 테스트 로그인 엔드포인트 생성
  - `user_id`를 통해 로그인 기능 추가

- `user_id`로 로그인을 한 경우에도 기존 로그인과 동일하게 모든 기능 사용 가능
- 테스트 용으로 적용 후 추후 제거 예정




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 테스트용 로그인 엔드포인트(`/v1/test-login`)가 추가되었습니다. 이 엔드포인트를 통해 사용자 ID만으로 인증 토큰을 발급받을 수 있습니다.
- **기타**
  - `/v1/test-login` 경로가 인증 미들웨어 예외 경로에 추가되어 인증 없이 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->