### PR TITLE
feat/be: Story, Illust, Choice 페이지별로 조회 기능 구현

### DIFF
--- a/ingq/app/macmorning.py
+++ b/ingq/app/macmorning.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -46,6 +47,7 @@ def create_app() -> FastAPI:
         "/docs",
         "/openapi.json",
         "/redoc",
+        re.compile(r"^/v1/book/\d+/story/\d+$"),
     ]
 
     app.container = container

--- a/ingq/choice/application/choice_service.py
+++ b/ingq/choice/application/choice_service.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timezone
+from typing import Optional
 
 from sqlalchemy.orm import Session
 
 from choice.domain.choice import Choice
 from choice.domain.repository.choice_repository import ChoiceRepository
-from choice.dto.schemas import CreateChoiceRequest, CreateChoiceResponse
+from choice.dto.schemas import ChoiceItem, CreateChoiceRequest, CreateChoiceResponse
 from choice.utils.mapper import ChoiceMapper
 
 
@@ -26,3 +27,13 @@ class ChoiceService:
         saved_choice = self.choice_repository.save(choice, db=session)
 
         return ChoiceMapper.to_create_choice_response(saved_choice)
+
+    def get_choice_item_by_story_id(
+        self, story_id: int, session: Session
+    ) -> Optional[ChoiceItem]:
+        choice = self.choice_repository.find_by_story_id(story_id, db=session)
+
+        if not choice:
+            return None
+
+        return ChoiceMapper.choicevo_to_choice_item(choice)

--- a/ingq/choice/domain/repository/choice_repository.py
+++ b/ingq/choice/domain/repository/choice_repository.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from typing import Optional
 
 from sqlalchemy.orm import Session
 
@@ -11,5 +12,5 @@ class ChoiceRepository(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def find_by_story_id(self, story_id: int, db: Session) -> Choice:
+    def find_by_story_id(self, story_id: int, db: Session) -> Optional[Choice]:
         raise NotImplementedError

--- a/ingq/choice/domain/repository/choice_repository.py
+++ b/ingq/choice/domain/repository/choice_repository.py
@@ -9,3 +9,7 @@ class ChoiceRepository(metaclass=ABCMeta):
     @abstractmethod
     def save(self, choice: Choice, db: Session) -> Choice:
         raise NotImplementedError
+
+    @abstractmethod
+    def find_by_story_id(self, story_id: int, db: Session) -> Choice:
+        raise NotImplementedError

--- a/ingq/choice/dto/schemas.py
+++ b/ingq/choice/dto/schemas.py
@@ -29,3 +29,17 @@ class CreateChoiceResponse(BaseModel):
     is_success: bool
     created_at: datetime
     updated_at: datetime
+
+
+# ============================================================================
+# Choice 조회 관련 DTO
+class ChoiceItem(BaseModel):
+    choice_id: int
+    story_id: int
+    first_choice: str
+    second_choice: str
+    third_choice: Optional[str]
+    my_choice: int
+    is_success: bool
+    created_at: datetime
+    updated_at: datetime

--- a/ingq/choice/infra/repository/mysql_choice_repository.py
+++ b/ingq/choice/infra/repository/mysql_choice_repository.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from sqlalchemy.orm import Session
 
 from choice.domain.choice import Choice as ChoiceVO
@@ -13,7 +15,7 @@ class MysqlChoiceRepository(ChoiceRepository):
         db.flush()
         return ChoiceMapper.choice_to_choicevo(new_choice)
 
-    def find_by_story_id(self, story_id: int, db: Session) -> ChoiceVO:
+    def find_by_story_id(self, story_id: int, db: Session) -> Optional[ChoiceVO]:
         choice = db.query(Choice).filter(Choice.story_id == story_id).first()
 
         if not choice:

--- a/ingq/choice/infra/repository/mysql_choice_repository.py
+++ b/ingq/choice/infra/repository/mysql_choice_repository.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 
 from choice.domain.choice import Choice as ChoiceVO
 from choice.domain.repository.choice_repository import ChoiceRepository
+from choice.infra.db_models.choice import Choice
 from choice.utils.mapper import ChoiceMapper
 
 
@@ -11,3 +12,11 @@ class MysqlChoiceRepository(ChoiceRepository):
         db.add(new_choice)
         db.flush()
         return ChoiceMapper.choice_to_choicevo(new_choice)
+
+    def find_by_story_id(self, story_id: int, db: Session) -> ChoiceVO:
+        choice = db.query(Choice).filter(Choice.story_id == story_id).first()
+
+        if not choice:
+            return None
+
+        return ChoiceMapper.choice_to_choicevo(choice)

--- a/ingq/choice/utils/mapper.py
+++ b/ingq/choice/utils/mapper.py
@@ -1,5 +1,5 @@
 from choice.domain.choice import Choice as ChoiceVO
-from choice.dto.schemas import CreateChoiceResponse
+from choice.dto.schemas import ChoiceItem, CreateChoiceResponse
 from choice.infra.db_models.choice import Choice
 
 
@@ -37,6 +37,21 @@ class ChoiceMapper:
     def choice_to_choicevo(choice: Choice) -> ChoiceVO:
         return ChoiceVO(
             id=choice.id,
+            story_id=choice.story_id,
+            first_choice=choice.first_choice,
+            second_choice=choice.second_choice,
+            third_choice=choice.third_choice,
+            my_choice=choice.my_choice,
+            is_success=choice.is_success,
+            created_at=choice.created_at,
+            updated_at=choice.updated_at,
+        )
+
+    # Domain 계층에서 사용하는 메서드
+    @staticmethod
+    def choicevo_to_choice_item(choice: ChoiceVO) -> ChoiceItem:
+        return ChoiceItem(
+            choice_id=choice.id,
             story_id=choice.story_id,
             first_choice=choice.first_choice,
             second_choice=choice.second_choice,

--- a/ingq/core/auth_middleware.py
+++ b/ingq/core/auth_middleware.py
@@ -29,7 +29,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         return False
 
     async def dispatch(self, request: Request, call_next):
-        if self.is_exempt_path(request.url.path):
+        if await self.is_exempt_path(request.url.path):
             request.state.current_user = None
             return await call_next(request)
 

--- a/ingq/core/auth_middleware.py
+++ b/ingq/core/auth_middleware.py
@@ -18,8 +18,18 @@ class AuthMiddleware(BaseHTTPMiddleware):
         self.jwt_token_provider = jwt_token_provider
         self.exempt_paths = exempt_paths
 
+    async def is_exempt_path(self, path: str) -> bool:
+        for pattern in self.exempt_paths:
+            if isinstance(pattern, str):
+                if path == pattern:
+                    return True
+            else:
+                if pattern.match(path):
+                    return True
+        return False
+
     async def dispatch(self, request: Request, call_next):
-        if request.url.path in self.exempt_paths:
+        if self.is_exempt_path(request.url.path):
             request.state.current_user = None
             return await call_next(request)
 

--- a/ingq/illust/application/illust_service.py
+++ b/ingq/illust/application/illust_service.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timezone
+from typing import Optional
 
 from sqlalchemy.orm import Session
 
 from illust.domain.illust import Illust
 from illust.domain.repository.illust_repository import IllustRepository
-from illust.dto.schemas import CreateIllustRequest, CreateIllustResponse
+from illust.dto.schemas import CreateIllustRequest, CreateIllustResponse, IllustItem
 from illust.utils.mapper import IllustMapper
 
 
@@ -25,3 +26,13 @@ class IllustService:
         saved_illust = self.illust_repository.save(illust, db=session)
 
         return IllustMapper.to_create_illust_response(saved_illust)
+
+    def get_illust_item_by_story_id(
+        self, story_id: int, session: Session
+    ) -> Optional[IllustItem]:
+        illust = self.illust_repository.find_by_story_id(story_id, db=session)
+
+        if not illust:
+            return None
+
+        return IllustMapper.illustvo_to_illust_item(illust)

--- a/ingq/illust/domain/repository/illust_repository.py
+++ b/ingq/illust/domain/repository/illust_repository.py
@@ -9,3 +9,7 @@ class IllustRepository(metaclass=ABCMeta):
     @abstractmethod
     def save(self, illust: Illust, db: Session) -> Illust:
         raise NotImplementedError
+
+    @abstractmethod
+    def find_by_story_id(self, story_id: int, db: Session) -> Illust:
+        raise NotImplementedError

--- a/ingq/illust/domain/repository/illust_repository.py
+++ b/ingq/illust/domain/repository/illust_repository.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from typing import Optional
 
 from sqlalchemy.orm import Session
 
@@ -11,5 +12,5 @@ class IllustRepository(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def find_by_story_id(self, story_id: int, db: Session) -> Illust:
+    def find_by_story_id(self, story_id: int, db: Session) -> Optional[Illust]:
         raise NotImplementedError

--- a/ingq/illust/dto/schemas.py
+++ b/ingq/illust/dto/schemas.py
@@ -13,3 +13,13 @@ class CreateIllustResponse(BaseModel):
     image_url: str
     created_at: datetime
     updated_at: datetime
+
+
+# ============================================================================
+# Illust 조회 관련 DTO
+class IllustItem(BaseModel):
+    illust_id: int
+    story_id: int
+    image_url: str
+    created_at: datetime
+    updated_at: datetime

--- a/ingq/illust/infra/repository/mysql_illust_repository.py
+++ b/ingq/illust/infra/repository/mysql_illust_repository.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 
 from illust.domain.illust import Illust as IllustVO
 from illust.domain.repository.illust_repository import IllustRepository
+from illust.infra.db_models.illust import Illust
 from illust.utils.mapper import IllustMapper
 
 
@@ -11,3 +12,11 @@ class MysqlIllustRepository(IllustRepository):
         db.add(new_illust)
         db.flush()
         return IllustMapper.illust_to_illustvo(new_illust)
+
+    def find_by_story_id(self, story_id: int, db: Session) -> IllustVO:
+        illust = db.query(Illust).filter(Illust.story_id == story_id).first()
+
+        if not illust:
+            return None
+
+        return IllustMapper.illust_to_illustvo(illust)

--- a/ingq/illust/infra/repository/mysql_illust_repository.py
+++ b/ingq/illust/infra/repository/mysql_illust_repository.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from sqlalchemy.orm import Session
 
 from illust.domain.illust import Illust as IllustVO
@@ -13,7 +15,7 @@ class MysqlIllustRepository(IllustRepository):
         db.flush()
         return IllustMapper.illust_to_illustvo(new_illust)
 
-    def find_by_story_id(self, story_id: int, db: Session) -> IllustVO:
+    def find_by_story_id(self, story_id: int, db: Session) -> Optional[IllustVO]:
         illust = db.query(Illust).filter(Illust.story_id == story_id).first()
 
         if not illust:

--- a/ingq/illust/utils/mapper.py
+++ b/ingq/illust/utils/mapper.py
@@ -1,5 +1,5 @@
 from illust.domain.illust import Illust as IllustVO
-from illust.dto.schemas import CreateIllustResponse
+from illust.dto.schemas import CreateIllustResponse, IllustItem
 from illust.infra.db_models.illust import Illust
 
 
@@ -29,6 +29,17 @@ class IllustMapper:
     def illust_to_illustvo(illust: Illust) -> IllustVO:
         return IllustVO(
             id=illust.id,
+            story_id=illust.story_id,
+            image_url=illust.image_url,
+            created_at=illust.created_at,
+            updated_at=illust.updated_at,
+        )
+
+    # Domain 계층에서 사용하는 메서드
+    @staticmethod
+    def illustvo_to_illust_item(illust: IllustVO) -> IllustItem:
+        return IllustItem(
+            illust_id=illust.id,
             story_id=illust.story_id,
             image_url=illust.image_url,
             created_at=illust.created_at,

--- a/ingq/story/application/story_service.py
+++ b/ingq/story/application/story_service.py
@@ -11,12 +11,14 @@ from story.domain.story import Story
 from story.dto.schemas import (
     CreateStoryWithIllustAndChoiceRequest,
     CreateStoryWithIllustAndChoiceResponse,
+    GetStoryWithIllustAndChoiceResponse,
 )
 from story.exception.story_exception import (
     DuplicatePageNumberException,
     InvalidBookProgressException,
     InvalidChoiceException,
     InvalidUserAccessException,
+    StoryNotFoundException,
 )
 from story.utils.mapper import StoryMapper
 
@@ -68,10 +70,10 @@ class StoryService:
         )
 
     def get_story_by_book_id_and_page_number(
-        self, book_id: int, page_number: int
+        self, book_id: int, page_number: int, db: Optional[Session] = None
     ) -> Optional[Story]:
         return self.story_repository.find_by_book_id_and_page_number(
-            book_id, page_number
+            book_id, page_number, db
         )
 
     def _validate_and_get_book(self, user_id, book_id, story_request):
@@ -101,3 +103,24 @@ class StoryService:
                 raise InvalidChoiceException()
             return self.choice_service.create_choice(story_id, choice_request, session)
         return None
+
+    def get_story_with_illust_and_choice(
+        self, user_id: str, book_id: int, page_number: int, session: Session
+    ) -> GetStoryWithIllustAndChoiceResponse:
+        book = self.book_service.get_book_by_id_or_throw(book_id)
+        story = self.get_story_by_book_id_and_page_number(
+            book_id, page_number, db=session
+        )
+
+        if not story:
+            raise StoryNotFoundException()
+
+        if book.is_in_progress:
+            if user_id is None or book.user_id != user_id:
+                raise InvalidUserAccessException()
+
+        return GetStoryWithIllustAndChoiceResponse(
+            story=StoryMapper.storyvo_to_story_item(story),
+            illust=self.illust_service.get_illust_item_by_story_id(story.id, session),
+            choice=self.choice_service.get_choice_item_by_story_id(story.id, session),
+        )

--- a/ingq/story/application/story_service.py
+++ b/ingq/story/application/story_service.py
@@ -107,20 +107,25 @@ class StoryService:
     def get_story_with_illust_and_choice(
         self, user_id: str, book_id: int, page_number: int, session: Session
     ) -> GetStoryWithIllustAndChoiceResponse:
-        book = self.book_service.get_book_by_id_or_throw(book_id)
-        story = self.get_story_by_book_id_and_page_number(
-            book_id, page_number, db=session
-        )
+        with session.begin():
+            book = self.book_service.get_book_by_id_or_throw(book_id)
+            story = self.get_story_by_book_id_and_page_number(
+                book_id, page_number, db=session
+            )
 
-        if not story:
-            raise StoryNotFoundException()
+            if not story:
+                raise StoryNotFoundException()
 
-        if book.is_in_progress:
-            if user_id is None or book.user_id != user_id:
-                raise InvalidUserAccessException()
+            if book.is_in_progress:
+                if user_id is None or book.user_id != user_id:
+                    raise InvalidUserAccessException()
 
-        return GetStoryWithIllustAndChoiceResponse(
-            story=StoryMapper.storyvo_to_story_item(story),
-            illust=self.illust_service.get_illust_item_by_story_id(story.id, session),
-            choice=self.choice_service.get_choice_item_by_story_id(story.id, session),
-        )
+            return GetStoryWithIllustAndChoiceResponse(
+                story=StoryMapper.storyvo_to_story_item(story),
+                illust=self.illust_service.get_illust_item_by_story_id(
+                    story.id, session
+                ),
+                choice=self.choice_service.get_choice_item_by_story_id(
+                    story.id, session
+                ),
+            )

--- a/ingq/story/domain/repository/story_repository.py
+++ b/ingq/story/domain/repository/story_repository.py
@@ -13,6 +13,6 @@ class StoryRepository(metaclass=ABCMeta):
 
     @abstractmethod
     def find_by_book_id_and_page_number(
-        self, book_id: int, page_number: int
+        self, book_id: int, page_number: int, db: Optional[Session] = None
     ) -> Optional[Story]:
         raise NotImplementedError

--- a/ingq/story/dto/schemas.py
+++ b/ingq/story/dto/schemas.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from choice.dto.schemas import CreateChoiceRequest, CreateChoiceResponse
-from illust.dto.schemas import CreateIllustRequest, CreateIllustResponse
+from choice.dto.schemas import ChoiceItem, CreateChoiceRequest, CreateChoiceResponse
+from illust.dto.schemas import CreateIllustRequest, CreateIllustResponse, IllustItem
 
 
 # ============================================================================
@@ -39,3 +39,27 @@ class CreateStoryWithIllustAndChoiceResponse(BaseModel):
     story: CreateStoryResponse
     illust: Optional[CreateIllustResponse] = None
     choice: Optional[CreateChoiceResponse] = None
+
+
+# ============================================================================
+# Story 조회 관련 DTO
+class GetStoryRequest(BaseModel):
+    book_id: int
+    page_number: int
+
+
+# Story 조회 시 반환 할 DTO
+class StoryItem(BaseModel):
+    story_id: int
+    book_id: int
+    page_number: int
+    story_text: str
+    created_at: datetime
+    updated_at: datetime
+
+
+# Story 조회 시 반환 할 DTO(이미지, 선택지 포함)
+class GetStoryWithIllustAndChoiceResponse(BaseModel):
+    story: StoryItem
+    illust: Optional[IllustItem] = None
+    choice: Optional[ChoiceItem] = None

--- a/ingq/story/exception/story_exception.py
+++ b/ingq/story/exception/story_exception.py
@@ -41,3 +41,12 @@ class InvalidUserAccessException(StoryException):
             status_code=status.HTTP_403_FORBIDDEN,
             detail="해당 책에 대한 접근 권한이 없습니다.",
         )
+
+
+class StoryNotFoundException(StoryException):
+    def __init__(self):
+        super().__init__(
+            code="STORY005",
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="해당 하는 스토리를 찾을 수 없습니다.",
+        )

--- a/ingq/story/infra/repository/mysql_story_repository.py
+++ b/ingq/story/infra/repository/mysql_story_repository.py
@@ -17,16 +17,23 @@ class MysqlStoryRepository(StoryRepository):
         return StoryMapper.story_to_storyvo(new_story)
 
     def find_by_book_id_and_page_number(
-        self, book_id: int, page_number: int
+        self, book_id: int, page_number: int, db: Optional[Session] = None
     ) -> Optional[StoryVO]:
-        with SessionLocal() as db:
+        if db is not None:
             story = (
                 db.query(Story)
                 .filter(Story.book_id == book_id, Story.page_number == page_number)
                 .first()
             )
+        else:
+            with SessionLocal() as local_db:
+                story = (
+                    local_db.query(Story)
+                    .filter(Story.book_id == book_id, Story.page_number == page_number)
+                    .first()
+                )
 
-            if not story:
-                return None
+        if not story:
+            return None
 
-            return StoryMapper.story_to_storyvo(story)
+        return StoryMapper.story_to_storyvo(story)

--- a/ingq/story/interface/controller/story_controller.py
+++ b/ingq/story/interface/controller/story_controller.py
@@ -2,12 +2,15 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.orm import Session
 
+from auth.application.jwt_token_provider import JwtTokenProvider
+from auth.utils.user_extractor import get_optional_current_user
 from db.database import get_db
 from dependencies.containers import Container
 from story.application.story_service import StoryService
 from story.dto.schemas import (
     CreateStoryWithIllustAndChoiceRequest,
     CreateStoryWithIllustAndChoiceResponse,
+    GetStoryWithIllustAndChoiceResponse,
 )
 
 router = APIRouter(prefix="/v1", tags=["Story Router"])
@@ -25,4 +28,23 @@ def create_story(
     current_user = request.state.current_user
     return story_service.create_story_with_illust_and_choice(
         current_user.id, book_id, create_story_with_illust_and_choice_request, session
+    )
+
+
+@router.get("/book/{book_id}/story/{page_number}", status_code=200)
+@inject
+def get_story_with_illust_and_choice(
+    request: Request,
+    book_id: int,
+    page_number: int,
+    story_service: StoryService = Depends(Provide[Container.story_service]),
+    jwt_token_provider: JwtTokenProvider = Depends(
+        Provide[Container.jwt_token_provider]
+    ),
+    session: Session = Depends(get_db),
+) -> GetStoryWithIllustAndChoiceResponse:
+    current_user = get_optional_current_user(request, jwt_token_provider)
+    user_id = current_user.id if current_user else None
+    return story_service.get_story_with_illust_and_choice(
+        user_id, book_id, page_number, session
     )

--- a/ingq/story/utils/mapper.py
+++ b/ingq/story/utils/mapper.py
@@ -1,5 +1,5 @@
 from story.domain.story import Story as StoryVO
-from story.dto.schemas import CreateStoryResponse
+from story.dto.schemas import CreateStoryResponse, StoryItem
 from story.infra.db_models.story import Story
 
 
@@ -31,6 +31,18 @@ class StoryMapper:
     def story_to_storyvo(story: Story) -> StoryVO:
         return StoryVO(
             id=story.id,
+            book_id=story.book_id,
+            page_number=story.page_number,
+            story_text=story.story_text,
+            created_at=story.created_at,
+            updated_at=story.updated_at,
+        )
+
+    # Domain 계층에서 사용하는 메서드
+    @staticmethod
+    def storyvo_to_story_item(story: StoryVO) -> StoryItem:
+        return StoryItem(
+            story_id=story.id,
             book_id=story.book_id,
             page_number=story.page_number,
             story_text=story.story_text,


### PR DESCRIPTION
## 주의
- [X] 브랜치 방향 확인하셨나요? :)

## 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->
- close #59 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

Story, Illust, Choice 한 번에 조회하는 엔드포인트 추가

책의 `is_in_progress`
- `True` 인 경우(이야기 진행중) : 로그인 한 사용자가 만든 책인 경우에만 조회 가능
- `False` 인 경우(이야기 완료) : 모든 사용자(로그인 하지 않은 사용자 포함)가 접근 가능



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 책과 페이지 번호로 스토리, 일러스트, 선택지를 함께 조회할 수 있는 GET API가 추가되었습니다.
    - 스토리, 일러스트, 선택지 정보를 반환하는 새로운 응답 구조가 도입되었습니다.
    - 인증 예외 경로가 확장되어 특정 스토리 조회 경로도 인증 없이 접근할 수 있습니다.

- **기타**
    - 스토리 조회 시 스토리가 없을 경우를 처리하는 새로운 예외가 추가되었습니다.
    - 스토리, 일러스트, 선택지 관련 데이터 전송 객체(DTO)와 매퍼 메서드가 추가되어 데이터 변환이 강화되었습니다.
    - 데이터베이스 조회 시 세션을 인자로 받아 트랜잭션 관리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->