### PR TITLE
feat/be: 토큰 및 저자 유무에 따른 선택지 목록 조회 방식 변경

### DIFF
--- a/ingq/app/macmorning.py
+++ b/ingq/app/macmorning.py
@@ -54,6 +54,7 @@ def create_app() -> FastAPI:
         "/redoc",
         re.compile(r"^/v1/book/\d+/story/\d+$"),
         re.compile(r"^/v1/book/\d+$"),
+        re.compile(r"^/v1/book/\d+/choice$"),
     ]
 
     app.container = container

--- a/ingq/choice/application/choice_service.py
+++ b/ingq/choice/application/choice_service.py
@@ -60,22 +60,39 @@ class ChoiceService:
     ) -> LastChoiceItemList:
         book = self.book_reader.get_book_by_id_or_throw(book_id)
 
-        if book.user_id != user_id:
-            raise InvalidUserAccessException()
+        if book.user_id == user_id:
+            choices = self.choice_repository.find_all_by_book_id(book.id)
 
-        choices = self.choice_repository.find_all_by_book_id(book.id)
+            last_choices = [
+                ChoiceMapper.choicevo_to_last_choice_item(
+                    choice,
+                    [choice.first_choice, choice.second_choice, choice.third_choice][
+                        choice.my_choice - 1
+                    ],
+                )
+                for choice in choices
+            ]
 
-        last_choices = [
-            ChoiceMapper.choicevo_to_last_choice_item(
-                choice,
-                [choice.first_choice, choice.second_choice, choice.third_choice][
-                    choice.my_choice - 1
-                ],
+            return LastChoiceItemList(choices=last_choices)
+
+        if user_id is None or book.user_id != user_id:
+            choices = (
+                self.choice_repository.find_all_by_book_id_where_reason_is_not_null(
+                    book.id
+                )
             )
-            for choice in choices
-        ]
 
-        return LastChoiceItemList(choices=last_choices)
+            last_choices = [
+                ChoiceMapper.choicevo_to_last_choice_item(
+                    choice,
+                    [choice.first_choice, choice.second_choice, choice.third_choice][
+                        choice.my_choice - 1
+                    ],
+                )
+                for choice in choices
+            ]
+
+            return LastChoiceItemList(choices=last_choices)
 
     def update_selected_choice(
         self,

--- a/ingq/choice/domain/repository/choice_repository.py
+++ b/ingq/choice/domain/repository/choice_repository.py
@@ -26,3 +26,9 @@ class ChoiceRepository(metaclass=ABCMeta):
     @abstractmethod
     def update_reason(self, choice: Choice) -> Choice:
         raise NotImplementedError
+
+    @abstractmethod
+    def find_all_by_book_id_where_reason_is_not_null(
+        self, book_id: int
+    ) -> list[Choice]:
+        raise NotImplementedError

--- a/ingq/choice/infra/repository/mysql_choice_repository.py
+++ b/ingq/choice/infra/repository/mysql_choice_repository.py
@@ -25,7 +25,7 @@ class MysqlChoiceRepository(ChoiceRepository):
 
         return ChoiceMapper.choice_to_choicevo(choice)
 
-    def find_all_by_book_id(self, book_id: int) -> list[Choice]:
+    def find_all_by_book_id(self, book_id: int) -> list[ChoiceVO]:
         with SessionLocal() as db:
             choices = (
                 db.query(Choice)
@@ -55,3 +55,15 @@ class MysqlChoiceRepository(ChoiceRepository):
             db.commit()
 
             return ChoiceMapper.choice_to_choicevo(db_choice)
+
+    def find_all_by_book_id_where_reason_is_not_null(
+        self, book_id: int
+    ) -> list[ChoiceVO]:
+        with SessionLocal() as db:
+            choices = (
+                db.query(Choice)
+                .join(Choice.story)
+                .filter(Story.book_id == book_id, Choice.reason.isnot(None))
+                .all()
+            )
+            return ChoiceMapper.choices_to_choicesvo(choices)

--- a/ingq/choice/interface/controller/choice_controller.py
+++ b/ingq/choice/interface/controller/choice_controller.py
@@ -1,6 +1,8 @@
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Request
 
+from auth.application.jwt_token_provider import JwtTokenProvider
+from auth.utils.user_extractor import get_optional_current_user
 from choice.application.choice_service import ChoiceService
 from choice.dto.schemas import LastChoiceItem, LastChoiceItemList, UpdateReasonRequest
 from dependencies.containers import Container
@@ -14,9 +16,13 @@ def get_all_selected_choice(
     request: Request,
     book_id: int,
     choice_service: ChoiceService = Depends(Provide[Container.choice_service]),
+    jwt_token_provider: JwtTokenProvider = Depends(
+        Provide[Container.jwt_token_provider]
+    ),
 ) -> LastChoiceItemList:
-    current_user = request.state.current_user
-    return choice_service.get_selected_choice_item_by_book_id(current_user.id, book_id)
+    current_user = get_optional_current_user(request, jwt_token_provider)
+    user_id = current_user.id if current_user else None
+    return choice_service.get_selected_choice_item_by_book_id(user_id, book_id)
 
 
 @router.post("/book/{book_id}/choice/{choice_id}")


### PR DESCRIPTION
## 주의
- [X] 브랜치 방향 확인하셨나요? :)

## 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->
- close #87 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->
- 기존: 각 책에 대한 선택지 목록은 저자만 조회 가능
- 변경: 로그인한 사용자가 저자와 일치한 경우 모든 선택지 목록 반환
           로그인한 사용자가 없거나, 저자가 아닐 경우 Choice의 reason 필드가 null이 아닌 경우만 반환


## 리뷰 요청 사항
<!-- 팀원들이 주의 깊게 살펴봐야하는 부분 및 리뷰가 필요한 곳에 대해 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 인증 없이도 `/v1/book/{book_id}/choice` 경로에서 선택 항목을 일부 조회할 수 있도록 지원합니다.
- **기능 개선**
    - 선택 항목 조회 시, 소유자가 아닌 사용자 또는 비로그인 사용자는 'reason'이 입력된 선택 항목만 조회할 수 있도록 변경되었습니다.
    - 인증 정보가 없을 때도 선택 항목 조회가 가능하도록 인증 처리 방식을 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->